### PR TITLE
Update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ function MQPackerFilter(inputTree, options) {
     return new MQPackerFilter(inputTree, options);
   }
 
-  this.inputTree = inputTree;
+  Filter.call(this, inputTree, options);
+
   this.options = options || {};
 }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.1",
   "description": "Media Queries combiner for Broccoli, using CSS MQPacker",
   "scripts": {
-    "lint": "jshint *.js test/*.js --reporter node_modules/jshint-stylish/stylish",
+    "lint": "jshint *.js test/*.js --reporter node_modules/jshint-stylish",
     "build": "rimraf test/actual && broccoli build test/actual",
     "pretest": "${npm_package_scripts_lint} && npm run-script build",
     "test": "mocha test/test.js --reporter spec --timeout 300",
@@ -43,13 +43,13 @@
   ],
   "dependencies": {
     "broccoli-filter": "^0.1.6",
-    "css-mqpacker": "^1.0.0"
+    "css-mqpacker": "^5.0.0"
   },
   "devDependencies": {
     "broccoli": "^0.12.3",
     "jshint": "^2.5.3",
-    "jshint-stylish": "^0.4.0",
-    "mocha": "^1.21.4",
+    "jshint-stylish": "^2.0.0",
+    "mocha": "^2.0.0",
     "q": "^2.0.2",
     "rimraf": "^2.2.8"
   }

--- a/package.json
+++ b/package.json
@@ -42,16 +42,16 @@
     "combine"
   ],
   "dependencies": {
-    "broccoli-filter": "^0.1.6",
+    "broccoli-filter": "^1.2.2",
     "css-mqpacker": "^5.0.0"
   },
   "devDependencies": {
-    "broccoli": "^0.12.3",
+    "broccoli": "^0.16.9",
     "css": "^2.2.1",
     "jshint": "^2.5.3",
     "jshint-stylish": "^2.0.0",
     "mocha": "^2.0.0",
-    "q": "^2.0.2",
-    "rimraf": "^2.2.8"
+    "q": "^1.4.1",
+    "rimraf": "^2.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "broccoli": "^0.12.3",
+    "css": "^2.2.1",
     "jshint": "^2.5.3",
     "jshint-stylish": "^2.0.0",
     "mocha": "^2.0.0",

--- a/test/expected/multiple_mediaqueries.css
+++ b/test/expected/multiple_mediaqueries.css
@@ -4,18 +4,20 @@
   position: absolute;
 }
 
-@media (min-width: 1px) {
-  a {
-      z-index: 1;
+@media (min-width: 1px){
+
+  a{
+    z-index: 1;
   }
 
-  b {
+  b{
     z-index: 2;
   }
 }
 
-@media (min-width: 2px) {
-  b {
+@media (min-width: 2px){
+
+  b{
     z-index: 2;
   }
 }

--- a/test/fixture/multiple_mediaqueries.css
+++ b/test/fixture/multiple_mediaqueries.css
@@ -6,7 +6,7 @@
 
 @media (min-width: 1px) {
   a {
-      z-index: 1;
+    z-index: 1;
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -3,8 +3,15 @@
 var assert = require('assert');
 var fs = require('fs');
 var Q = require('q');
+var css = require('css');
 
 var readFile = Q.denodeify(fs.readFile);
+
+function normalizeCSS(content) {
+  return css.stringify(
+    css.parse(content)
+  );
+}
 
 describe('broccoli-css-mqpacker', function() {
   it('should run css-mqpacker', function() {
@@ -12,7 +19,9 @@ describe('broccoli-css-mqpacker', function() {
       readFile('test/actual/multiple_mediaqueries.css'),
       readFile('test/expected/multiple_mediaqueries.css'),
     ]).spread(function(actual, expected) {
-      assert.strictEqual(actual.toString(), expected.toString());
+      actual = normalizeCSS(actual.toString());
+      expected = normalizeCSS(expected.toString());
+      assert.strictEqual(actual, expected);
     });
   });
 });


### PR DESCRIPTION
Updates to the latest version of `node-css-mq-packer` as well as some of the other Broccoli plugins.  I had to update the "expected" file in the tests to ensure that the format still matches the exact output.

~~In the future, I might update the tests to verify that the structure of the produced CSS is the same, maybe using something that can interpret the output as an AST and do the comparison that way.~~

Never mind, I added the CSS parsing in.
